### PR TITLE
Install iptables during image setup

### DIFF
--- a/oobe.sh
+++ b/oobe.sh
@@ -35,6 +35,10 @@ apk add --no-cache ca-certificates
 update-ca-certificates
 echo "Certificates setup complete"
 
+echo "Installing iptables..."
+apk add --no-cache iptables
+echo "iptables installed"
+
 echo "Fixing cgroups..."
 apk add --no-cache openrc
 sed -i 's/^#rc_cgroup_mode="unified"/rc_cgroup_mode="unified"/' /etc/rc.conf
@@ -46,7 +50,7 @@ chmod 1777 /var/tmp
 echo "Permissions fixed"
 
 echo "Setting version..."
-echo "version: 3" > /home/$DEFAULT_USER/version.txt
+echo "version: 4" > /home/$DEFAULT_USER/version.txt
 chown $DEFAULT_USER:$DEFAULT_USER /home/$DEFAULT_USER/version.txt
 echo "Version set"
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Install iptables during image setup so firewall rules can be managed out of the box. Updated the default user version file to 4.

<sup>Written for commit 758eb577ccf6d098952271c89de4ad1f593ae49d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

