### PR TITLE
Mount /tmp folder to tmpfs.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 # This file is part of BOINC.
 # https://boinc.berkeley.edu
-# Copyright (C) 2025 University of California
+# Copyright (C) 2026 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License
@@ -34,6 +34,7 @@ cp ./wsl.conf ./alpine/etc/
 mkdir -p ./alpine/usr/lib/wsl
 cp ./boinc.ico ./alpine/usr/lib/wsl/
 cp ./terminal-profile.json ./alpine/usr/lib/wsl/
+echo "tmpfs /tmp tmpfs defaults,noatime,mode=1777,size=50% 0 0" >> ./alpine/etc/fstab
 
 cd alpine
 tar --numeric-owner --absolute-names -c  * | gzip --best > ../install.tar.gz

--- a/oobe.sh
+++ b/oobe.sh
@@ -2,7 +2,7 @@
 
 # This file is part of BOINC.
 # https://boinc.berkeley.edu
-# Copyright (C) 2025 University of California
+# Copyright (C) 2026 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License
@@ -50,7 +50,7 @@ chmod 1777 /var/tmp
 echo "Permissions fixed"
 
 echo "Setting version..."
-echo "version: 4" > /home/$DEFAULT_USER/version.txt
+echo "version: 5" > /home/$DEFAULT_USER/version.txt
 chown $DEFAULT_USER:$DEFAULT_USER /home/$DEFAULT_USER/version.txt
 echo "Version set"
 


### PR DESCRIPTION
Set image version to 5.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mount /tmp on tmpfs to speed up temp I/O and reduce disk writes. Also upgrade the base to Alpine 3.23.2 and bump the image version to 5.

- **Dependencies**
  - Upgrade Alpine from 3.22.1 to 3.23.2.

- **Migration**
  - /tmp is now tmpfs (size=50%), cleared on reboot. Ensure no workflows rely on persistent /tmp.

<sup>Written for commit f415480296383692a68b37ec860b6b9a7c5c43aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



