### PR TITLE
Switch to Debian Trixie. Add CUDA support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 # This file is part of BOINC.
 # https://boinc.berkeley.edu
-# Copyright (C) 2025 University of California
+# Copyright (C) 2026 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License
@@ -25,10 +25,16 @@ on:
 jobs:
   build:
     name: build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        arch: [ x86_64, aarch64 ]
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+            platform: linux/amd64
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+            platform: linux/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,7 +42,8 @@ jobs:
       - name: Build
         if: success()
         run: |
-          ./build.sh ${{ matrix.arch }}
+          docker build . -t wsl-builder --platform ${{ matrix.platform }}
+          docker run --rm -v ${{ github.workspace }}:/app wsl-builder /app/build.sh ${{ matrix.arch }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 boinc-buda-runner.wsl
 # Vim swap files
 *.swp
+# build artifacts
+*.wsl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM debian:trixie
+
+RUN apt update && apt install -y \
+    qemu-user \
+    qemu-user-binfmt \
+    mmdebstrap
+
+WORKDIR /app
+
+CMD ["/bin/bash"]

--- a/build.sh
+++ b/build.sh
@@ -17,27 +17,73 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
+# This script is heavily based on the https://salsa.debian.org/debian/WSL/-/raw/master/create-targz.sh script, which is licensed under the MIT License.
+
 set -e
 
-arch=$1
+BUILDIR=$(pwd)
+ROOTFSDIR="$BUILDIR/rootfs"
+mkdir -p "$ROOTFSDIR"
+TMPDIR_X64=$(mktemp -d -p "$ROOTFSDIR")
+TMPDIR_ARM64=$(mktemp -d -p "$ROOTFSDIR")
 
-url="https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/${arch}/alpine-minirootfs-3.22.1-${arch}.tar.gz"
+DIST="trixie"
 
-curl -L $url -o alpine.tar.gz
-mkdir -p alpine
-tar -xzf alpine.tar.gz -C alpine --strip-components=1
-rm alpine.tar.gz
+cleanup() {
+    rm -rf "$ROOTFSDIR"
+}
+trap cleanup EXIT
 
-cp ./oobe.sh ./alpine/etc/
-cp ./wsl-distribution.conf ./alpine/etc/
-cp ./wsl.conf ./alpine/etc/
-mkdir -p ./alpine/usr/lib/wsl
-cp ./boinc.ico ./alpine/usr/lib/wsl/
-cp ./terminal-profile.json ./alpine/usr/lib/wsl/
-echo "tmpfs /tmp tmpfs defaults,noatime,mode=1777,size=50% 0 0" >> ./alpine/etc/fstab
+create_rootfs() {
+    local target_arch="$1"
+    local debian_arch tmpdir
 
-cd alpine
-tar --numeric-owner --absolute-names -c  * | gzip --best > ../install.tar.gz
-cd ..
-rm -rf alpine
-mv install.tar.gz boinc-buda-runner-${arch}.wsl
+    case "$target_arch" in
+        x86_64)
+            debian_arch="amd64"
+            tmpdir="$TMPDIR_X64"
+            ;;
+        aarch64)
+            debian_arch="arm64"
+            tmpdir="$TMPDIR_ARM64"
+            ;;
+        *)
+            echo "Unknown architecture: $target_arch" >&2
+            return 1
+            ;;
+    esac
+
+    cd "$tmpdir"
+
+    mmdebstrap --arch "$debian_arch" --include=sudo,locales,libpam-systemd,dbus,ca-certificates "$DIST" "$DIST" "$BUILDIR/debian.sources"
+    chroot "$DIST" apt-get clean
+    chroot "$DIST" /bin/bash -c "echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && locale-gen"
+    chroot "$DIST" /bin/bash -c "update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8"
+    cp "$BUILDIR/wsl-distribution.conf" "$tmpdir/$DIST/etc/wsl-distribution.conf"
+    cp "$BUILDIR/wsl.conf" "$tmpdir/$DIST/etc/wsl.conf"
+    mkdir -p "$tmpdir/$DIST/usr/lib/wsl/"
+    cp "$BUILDIR/oobe.sh" "$tmpdir/$DIST/etc/oobe.sh"
+    chmod 755 "$tmpdir/$DIST/etc/oobe.sh"
+    cp "$BUILDIR/boinc.ico" "$tmpdir/$DIST/usr/lib/wsl/boinc.ico"
+    cp "$BUILDIR/terminal-profile.json" "$tmpdir/$DIST/usr/lib/wsl/"
+    mkdir -p "$tmpdir/$DIST/etc/containers"
+    cp "$BUILDIR/containers.conf" "$tmpdir/$DIST/etc/containers/containers.conf"
+    rm -f "$tmpdir/$DIST/etc/resolv.conf"
+
+    cd "$DIST"
+    tar --numeric-owner --absolute-names -c  * | gzip --best > "$tmpdir/install.tar.gz"
+    mv -f "$tmpdir/install.tar.gz" "$BUILDIR/boinc-buda-runner-${target_arch}.wsl"
+}
+
+case "$1" in
+    x86_64)
+        create_rootfs "x86_64"
+        ;;
+    aarch64)
+        create_rootfs "aarch64"
+        ;;
+    *)
+        echo "Usage: $0 [x86_64|aarch64]" >&2
+        exit 1
+        ;;
+esac

--- a/containers.conf
+++ b/containers.conf
@@ -1,0 +1,2 @@
+[network]
+firewall_driver = "iptables"

--- a/debian.sources
+++ b/debian.sources
@@ -1,0 +1,12 @@
+Types: deb
+URIs: https://deb.debian.org/debian
+Suites: trixie trixie-updates trixie-backports
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.pgp
+
+Types: deb
+URIs: https://security.debian.org/debian-security
+Suites: trixie-security
+Components: main
+Signed-By: /usr/share/keyrings/debian-archive-keyring.pgp
+

--- a/oobe.sh
+++ b/oobe.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # This file is part of BOINC.
 # https://boinc.berkeley.edu
@@ -23,41 +23,74 @@ DEFAULT_UID='1000'
 DEFAULT_USER='boinc'
 
 echo "Creating default user account '$DEFAULT_USER'..."
-if getent passwd "$DEFAULT_UID" > /dev/null ; then
-  echo "User account '$DEFAULT_USER' already exists, skipping creation"
-  exit 0
-fi
-/usr/sbin/adduser -D --uid "$DEFAULT_UID" --gecos '' "$DEFAULT_USER"
+/usr/sbin/useradd -m -u "$DEFAULT_UID" -c '' -s /bin/sh "$DEFAULT_USER"
 echo "User account '$DEFAULT_USER' created"
 
+echo "Updating package index..."
+apt update
+echo "Package index updated"
+
 echo "Setting up certificates..."
-apk add --no-cache ca-certificates
+apt install -y ca-certificates
 update-ca-certificates
 echo "Certificates setup complete"
-
-echo "Installing iptables..."
-apk add --no-cache iptables
-echo "iptables installed"
-
-echo "Fixing cgroups..."
-apk add --no-cache openrc
-sed -i 's/^#rc_cgroup_mode="unified"/rc_cgroup_mode="unified"/' /etc/rc.conf
-rc-update add cgroups
-echo "cgroups fixed"
 
 echo "Fixing permissions..."
 chmod 1777 /var/tmp
 echo "Permissions fixed"
 
 echo "Setting version..."
-echo "version: 5" > /home/$DEFAULT_USER/version.txt
+echo "version: 6" > /home/$DEFAULT_USER/version.txt
 chown $DEFAULT_USER:$DEFAULT_USER /home/$DEFAULT_USER/version.txt
 echo "Version set"
 
+GPUS_JSON=/home/${DEFAULT_USER}/gpus.json
+
+if [ -f /usr/lib/wsl/lib/libcuda.so ]; then
+    echo "Setting up NVIDIA Container Toolkit..."
+    apt install -y gnupg2 curl
+    curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+    apt update
+    apt install -y nvidia-container-toolkit
+    systemctl enable --now nvidia-cdi-refresh.path
+    systemctl enable --now nvidia-cdi-refresh.service
+    nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml
+
+    found=0
+    json="{\"gpus\":["
+    CUDA_TXT=/var/tmp/cuda.txt
+    /usr/lib/wsl/lib/nvidia-smi -L > ${CUDA_TXT}
+    echo "CUDA GPU(s) detected:"
+    while read -r line; do
+        if [[ "$line" =~ ^GPU[[:space:]]+([0-9]+):[[:space:]]*(.*)[[:space:]]+\(UUID: ]]; then
+            gpu_number="${BASH_REMATCH[1]}"
+            gpu_name="${BASH_REMATCH[2]}"
+            if [ "x$gpu_number" != "x" ] && [ "x$gpu_name" != "x" ]; then
+                echo "$gpu_number: $gpu_name"
+                if [ $found -eq 1 ]; then
+                    json="$json,"
+                fi
+                json="$json{\"name\":\"nvidia\",\"has_cuda\":true,\"has_opencl\":false,\"gpu_name\":\"$gpu_name\",\"cuda_number\":$gpu_number,\"opencl_number\":null}"
+                found=1
+            fi
+        fi
+    done < ${CUDA_TXT}
+    rm -f ${CUDA_TXT}
+    json="$json]}"
+    if [ $found -eq 1 ]; then
+        echo $json > ${GPUS_JSON}
+    fi
+    echo "NVIDIA Container Toolkit setup complete"
+else
+    echo "No CUDA GPU detected"
+fi
+
+if [ -f ${GPUS_JSON} ]; then
+    chown $DEFAULT_USER:$DEFAULT_USER ${GPUS_JSON}
+fi
+
 echo "Setting up podman..."
-apk add --no-cache podman
-modprobe tun
-echo tun >>/etc/modules
+apt install -y podman iptables
 echo $DEFAULT_USER:100000:65536 >/etc/subuid
 echo $DEFAULT_USER:100000:65536 >/etc/subgid
 echo "Podman setup complete"

--- a/wsl.conf
+++ b/wsl.conf
@@ -2,7 +2,7 @@
 
 # This file is part of BOINC.
 # https://boinc.berkeley.edu
-# Copyright (C) 2025 University of California
+# Copyright (C) 2026 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License
@@ -18,4 +18,4 @@
 # along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
 [boot]
-systemd=false
+systemd=true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches the WSL rootfs from Alpine to Debian Trixie and adds CUDA support. Old behavior: Alpine image without systemd or GPU; new behavior: Debian Trixie with systemd enabled, `podman` networking via `iptables`, and automatic NVIDIA Container Toolkit setup when CUDA is available.

- CI/build: Runs in Docker (`debian:trixie`) using `mmdebstrap` with `qemu-user`/`qemu-user-binfmt`; matrix assigns `ubuntu-latest` for `x86_64` and `ubuntu-24.04-arm` for `aarch64` with Docker `--platform`. Artifacts remain `boinc-buda-runner-<arch>.wsl`. Adds `Dockerfile`, `debian.sources`; `.gitignore` now ignores `*.wsl`.
- Rootfs/runtime: `build.sh` creates a Debian Trixie rootfs with locales, `libpam-systemd`, `dbus`; sets `systemd=true` in `wsl.conf`; installs `/etc/containers/containers.conf` to force `iptables`. `oobe.sh` uses `apt`, installs `podman` and `iptables`; when `/usr/lib/wsl/lib/libcuda.so` exists, installs `nvidia-container-toolkit`, enables `nvidia-cdi-refresh` units, generates CDI via `nvidia-ctk`, and writes detected GPUs to `/home/boinc/gpus.json`.
- Required migration: Update scripts from `apk`/`openrc` to `apt`/systemd. Ensure WSL has systemd enabled. For CUDA, install Windows/NVIDIA drivers that expose `/usr/lib/wsl/lib/libcuda.so`.

<sup>Written for commit 0913dfb90b0fa10f8d66845684430cfb64cce54f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc-buda-runner-wsl/pull/20?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

